### PR TITLE
Revert "compute certificate hashes"

### DIFF
--- a/apkaye/apkaye.py
+++ b/apkaye/apkaye.py
@@ -1,6 +1,5 @@
 import os
 import time
-import hashlib
 from subprocess import Popen, PIPE, call
 
 from apkaye.static import ALL_ANDROID_PERMISSIONS, ISO_LOCALES
@@ -53,13 +52,6 @@ class APKaye(ServiceBase):
                 cur_file = os.path.join(root, f)
                 stdout = keytool_printcert(cur_file)
                 if stdout:
-                    # 'keytool' returns key error if cur_file is not a certificate;
-                    # 'keytool_printcert' returns None if key error;
-                    # compute cert file hash info
-                    cert_md5 = hashlib.md5(cur_file).hexdigest()
-                    cert_sha1 = hashlib.sha1(cur_file).hexdigest()
-                    cert_sha256 = hashlib.sha256(cur_file).hexdigest()
-
                     certs = certificate_chain_from_printcert(stdout)
                     has_cert = True
 
@@ -78,9 +70,6 @@ class APKaye(ServiceBase):
                         res_cert.add_tag('cert.valid.end', cert.valid_to)
                         res_cert.add_tag('cert.issuer', cert.issuer)
                         res_cert.add_tag('cert.owner', cert.owner)
-                        res_cert.add_tag('cert.thumbprint', cert_md5)
-                        res_cert.add_tag('cert.thumbprint', cert_sha1)
-                        res_cert.add_tag('cert.thumbprint', cert_sha256)
 
                         valid_from_splitted = cert.valid_from.split(" ")
                         valid_to_splitted = cert.valid_to.split(" ")


### PR DESCRIPTION
@spelcha Looks like this PR caused a bunch of crashes.

Reverts CybercentreCanada/assemblyline-service-apkaye#8

```
Nonrecoverable Service Error 
Strings must be encoded before hashing: File "/var/lib/assemblyline/.local/lib/python3.9/site-packages/assemblyline_v4_service/common/base.py", line 133, in handle_task self.execute(request) File "/opt/al_service/apkaye/apkaye.py", line 42, in execute self.run_apktool(apk, apktool_out, apktool_workdir, result) File "/opt/al_service/apkaye/apkaye.py", line 391, in run_apktool self.analyse_apktool_output(target_dir, result) File "/opt/al_service/apkaye/apkaye.py", line 384, in analyse_apktool_output self.validate_certs(apktool_out_dir, result) File "/opt/al_service/apkaye/apkaye.py", line 59, in validate_certs cert_md5 = hashlib.md5(cur_file).hexdigest() TypeError: Strings must be encoded before hashing
```
